### PR TITLE
删除插件movie中测试代码里调用handle的多余参数None

### DIFF
--- a/slack_bot/plugins/movie.py
+++ b/slack_bot/plugins/movie.py
@@ -78,5 +78,5 @@ def handle(data, app, **kwargs):
 
 
 if __name__ == '__main__':
-    print handle({'message': '最近要将上映的电影'}, None, None)
-    print handle({'message': '有什么电影 上海'}, None, None)
+    print handle({'message': '最近要将上映的电影'}, None)
+    print handle({'message': '有什么电影 上海'}, None)


### PR DESCRIPTION
直接运行movie.py插件发现调用handle方法时多了一个参数None，删掉了多余参数。
